### PR TITLE
A handful of assorted fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+build/
 env/
 *.pyc

--- a/source/contributing.rst
+++ b/source/contributing.rst
@@ -121,8 +121,8 @@ version of your contribution for feedback in no way prejudices your chances of
 getting that contribution accepted, and can save you from putting a lot of work
 into a contribution that is not suitable for the project.
 
-Contribution Suitablility
-~~~~~~~~~~~~~~~~~~~~~~~~~
+Contribution Suitability
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 The maintainers of a sub-project have the last word on whether or
 not a contribution is suitable for that project. We consider all contributions,

--- a/source/contributing.rst
+++ b/source/contributing.rst
@@ -19,10 +19,10 @@ We've organized this guide into sections:
 - general guidelines for all contributors
 - specific information based on the type of contribution you’re
   thinking of making
-       - code contributions
-       - documentation
-       - bug reports
-       - feature requests
+       - :ref:`code-contributions`
+       - :ref:`documentation-contributions`
+       - :ref:`bug-reports`
+       - :ref:`feature-requests`
 
 Code Of Conduct
 ---------------
@@ -137,6 +137,9 @@ If your contribution is rejected, don’t despair! So long as you followed these
 guidelines, you’ll have a much better chance of getting your next contribution
 accepted.
 
+
+.. _code-contributions:
+
 Code Contributions
 ------------------
 
@@ -206,6 +209,9 @@ Security
 We have a security policy we take very seriously. Please read :doc:`security`
 for more details.
 
+
+.. _documentation-contributions:
+
 Documentation Contributions
 ---------------------------
 
@@ -231,6 +237,8 @@ confirm that the bug hasn't been reported before. Duplicate bug reports are a
 huge drain on the time of other contributors, and should be avoided as much as
 possible.
 
+
+.. _feature-requests:
 
 Feature Requests
 ----------------

--- a/source/one-of-the-team.rst
+++ b/source/one-of-the-team.rst
@@ -26,7 +26,7 @@ Responsibility
 
 Becoming a contributor grants you quite a lot of power: in particular, you can
 merge pull requests and close bug reports. These can potentially give
-mischevious or malicious individuals the ability to cause a great deal of
+mischievous or malicious individuals the ability to cause a great deal of
 annoyance for everyone else.
 
 That's not a reason not to share these powers: we believe our community is full


### PR DESCRIPTION
* Two spelling fixes found by aspell.
* Add the Sphinx output directory to `.gitignore`.
* Make the items in the Contributing contents into links, per @Lukasa’s comment on #20.